### PR TITLE
通知設定書籍の追加処理実装

### DIFF
--- a/app/Http/Controllers/API/BookController.php
+++ b/app/Http/Controllers/API/BookController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\API;
 use App\Http\Controllers\Controller;
 use App\Models\Book;
 use App\Models\FavoriteBook;
+use App\Models\NotificationBook;
 use App\Models\ReadBook;
 use App\Models\User;
 use Illuminate\Http\JsonResponse;
@@ -93,6 +94,42 @@ class BookController extends Controller
                 if ($favorite) {
                     $favorite->delete();
                 }
+            }
+        });
+
+        return response()->json(['status' => 'success']);
+    }
+
+    public function toggleNotification(Request $request): JsonResponse
+    {
+        $user = User::findorFail($request->input('user_id'));
+        $isbn = $request->input('isbn');
+        $bookService = $this->bookService;
+
+        \DB::transaction(static function () use ($user, $isbn, $request, $bookService) {
+            $book = Book::firstOrCreate(
+                ['isbn' => $isbn],
+                ['title' => $request->input('title'), 'thumbnail' => $request->input('thumbnail')]
+            );
+            if ($book->authors()->doesntExist()) {
+                $authors = $request->input('authors', []);
+                foreach ($authors as $author) {
+                    $book->authors()->firstOrCreate(['name' => $author]);
+                }
+            }
+
+            $notification = NotificationBook::where('user_id', $user->id)->where('book_id', $book->id)->first();
+
+            if ($notification) {
+                $notification->delete();
+                if ($bookService->hasNoRelations($book)) {
+                    $book->delete();
+                }
+            } else {
+                $user->notificationBooks()->attach($book->id, [
+                    'created_at' => Carbon::now(),
+                    'updated_at' => Carbon::now(),
+                ]);
             }
         });
 

--- a/app/Http/Controllers/Admin/ReviewController.php
+++ b/app/Http/Controllers/Admin/ReviewController.php
@@ -3,8 +3,10 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
+use App\Models\Book;
 use Illuminate\Http\Request;
 use App\Models\Review;
+use App\Services\BookService;
 use App\Services\ReviewService;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\View\View;
@@ -12,7 +14,8 @@ use Illuminate\View\View;
 class ReviewController extends Controller
 {
     public function __construct(
-        protected ReviewService $reviewService
+        protected ReviewService $reviewService,
+        protected BookService $bookService
     ) {
     }
 
@@ -37,7 +40,7 @@ class ReviewController extends Controller
         $book = $review->book;
 
         $review->delete();
-        if ($book->favorites()->doesntExist() && $book->reviews()->doesntExist()) {
+        if ($this->bookService->hasNoRelations($book)) {
             $book->delete();
         }
 

--- a/app/Http/Controllers/User/BookController.php
+++ b/app/Http/Controllers/User/BookController.php
@@ -40,8 +40,9 @@ class BookController extends Controller
         $bookModel = Book::with(['reviews.user', 'reviews.categories', 'reviews.levelCategories'])->where('isbn', $isbn)->first();
         $isFavorite = $bookModel ? $user->favoriteBooks()->where('book_id', $bookModel->id)->exists() : false;
         $isRead = $bookModel ? $user->readBooks()->where('book_id', $bookModel->id)->exists() : false;
+        $isNotification = $bookModel ? $user->notificationBooks()->where('book_id', $bookModel->id)->exists() : false;
         $reviews = $bookModel ? $bookModel->reviews->sortByDesc('created_at') : [];
 
-        return view('user.books.show', ['user' => $user, 'book' => $book, 'isFavorite' => $isFavorite, 'isRead' => $isRead, 'reviews' => $reviews]);
+        return view('user.books.show', ['user' => $user, 'book' => $book, 'isFavorite' => $isFavorite, 'isRead' => $isRead, 'reviews' => $reviews, 'isNotification' => $isNotification]);
     }
 }

--- a/app/Http/Controllers/User/NotificationBookController.php
+++ b/app/Http/Controllers/User/NotificationBookController.php
@@ -4,8 +4,17 @@ namespace App\Http\Controllers\User;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
+use App\Models\Book;
+use Illuminate\View\View;
 
 class NotificationBookController extends Controller
 {
-    //
+    public function index(): View
+    {
+        $user = auth()->user();
+        $notificationBookIds = $user->notificationBooks()->pluck('book_id');
+        $books = Book::whereIn('id', $notificationBookIds)->with('authors')->latest()->paginate(12);
+
+        return view('user.notification_books.index', ['books' => $books, 'user' => $user]);
+    }
 }

--- a/app/Http/Controllers/User/NotificationBookController.php
+++ b/app/Http/Controllers/User/NotificationBookController.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Http\Controllers\User;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class NotificationBookController extends Controller
+{
+    //
+}

--- a/app/Http/Controllers/User/ReviewController.php
+++ b/app/Http/Controllers/User/ReviewController.php
@@ -12,6 +12,7 @@ use App\Models\LevelCategory;
 use App\Models\ReviewLevelCategory;
 use App\Models\Review;
 use App\Models\ReviewCategory;
+use App\Services\BookService;
 use App\Services\ReviewService;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\View\View;
@@ -21,7 +22,8 @@ class ReviewController extends Controller
 {
     public function __construct(
         protected googleBooksApiLibrary $googleBooksApiLibrary,
-        protected ReviewService $reviewService
+        protected ReviewService $reviewService,
+        protected BookService $bookService
     ) {
     }
 
@@ -87,7 +89,7 @@ class ReviewController extends Controller
         $book = $review->book;
 
         $review->delete();
-        if ($book->favorites()->doesntExist() && $book->reads()->doesntExist() && $book->reviews()->doesntExist()) {
+        if ($this->bookService->hasNoRelations($book)) {
             $book->delete();
         }
 

--- a/app/Models/Book.php
+++ b/app/Models/Book.php
@@ -32,4 +32,9 @@ class Book extends Model
     {
         return $this->belongsToMany(User::class, 'read_books');
     }
+
+    public function notifications(): belongsToMany
+    {
+        return $this->belongsToMany(User::class, 'notification_books');
+    }
 }

--- a/app/Models/NotificationBook.php
+++ b/app/Models/NotificationBook.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class NotificationBook extends Model
+{
+    use HasFactory;
+
+    protected $guarded = [];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -61,4 +61,9 @@ class User extends Authenticatable
     {
         return $this->belongsToMany(Book::class, 'read_books');
     }
+
+    public function notificationBooks(): belongsToMany
+    {
+        return $this->belongsToMany(Book::class, 'notification_books');
+    }
 }

--- a/app/Services/BookService.php
+++ b/app/Services/BookService.php
@@ -46,6 +46,6 @@ class BookService
     // お気に入り、読書、レビューの関連チェック
     public function hasNoRelations(Book $book): bool
     {
-        return !$book->favorites()->exists() && !$book->reads()->exists() && !$book->reviews()->exists();
+        return !$book->favorites()->exists() && !$book->reads()->exists() && !$book->reviews()->exists() && !$book->notifications()->exists();
     }
 }

--- a/app/Services/BookService.php
+++ b/app/Services/BookService.php
@@ -42,4 +42,10 @@ class BookService
 
         return [];
     }
+
+    // お気に入り、読書、レビューの関連チェック
+    public function hasNoRelations(Book $book): bool
+    {
+        return !$book->favorites()->exists() && !$book->reads()->exists() && !$book->reviews()->exists();
+    }
 }

--- a/database/migrations/2024_06_16_210510_create_notification_books_table.php
+++ b/database/migrations/2024_06_16_210510_create_notification_books_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('notification_books', static function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->foreignId('book_id')->constrained()->onDelete('cascade');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('notification_books');
+    }
+};

--- a/resources/views/components/parts/user_header.blade.php
+++ b/resources/views/components/parts/user_header.blade.php
@@ -69,6 +69,10 @@
                                 {{ __('Logout') }}
                             </a>
 
+                            <a class="dropdown-item" href="{{ route('user.notification_books.index') }}">
+                                {{ __('通知設定済書籍一覧') }}
+                            </a>
+
                             <a class="dropdown-item" href="{{ route('user.emails.edit') }}">
                                 {{ __('メールアドレス変更') }}
                             </a>

--- a/resources/views/user/books/show.blade.php
+++ b/resources/views/user/books/show.blade.php
@@ -78,6 +78,14 @@
                                             <div class="mt-1">
                                                 <a v-if="info.reserveurl" :href="info.reserveurl" class="btn btn-primary mt-2" target="_blank">この本を予約する</a>
                                             </div>
+                                            <div class="mt-1">
+                                                <button v-if="!Object.values(info.libkey).includes('貸出可') && !isNotification" class="btn btn-outline-success mt-2" @click="toggleNotification">
+                                                    <i class="fas fa-bell"></i> 貸出可能になったとき通知する
+                                                </button>
+                                                <button v-if="!Object.values(info.libkey).includes('貸出可') && isNotification" class="btn btn-success mt-2" @click="toggleNotification">
+                                                    <i class="fas fa-bell"></i> 通知設定済み
+                                                </button>
+                                            </div>
                                         </div>
                                         <div v-else>
                                             <span class="badge bg-secondary fs-6">蔵書なし</span>
@@ -163,6 +171,7 @@
                 errorMessage: null,
                 isFavorite: {{ $isFavorite ? 'true' : 'false' }},
                 isRead: {{ $isRead ? 'true' : 'false' }},
+                isNotification: {{ $isNotification ? 'true' : 'false' }}
             };
         },
         mounted() {
@@ -242,6 +251,28 @@
                     alert('読んだの登録に失敗しました');
                 })
             },
+            toggleNotification() {
+                fetch(`/api/books/toggleNotification`, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify({
+                        isbn: this.isbn,
+                        user_id: '{{ $user->id }}',
+                        title : '{{ optional($book)['title'] }}',
+                        thumbnail: '{{ optional($book)['thumbnail'] }}',
+                        authors: @json(optional($book)['authors']),
+                    }),
+                })
+                .then(response => response.json())
+                .then(data => {
+                    this.isNotification = !this.isNotification;
+                })
+                .catch(error => {
+                    alert('通知設定に失敗しました');
+                })
+            }
         }
     }).mount('#app');
 </script>

--- a/resources/views/user/notification_books/index.blade.php
+++ b/resources/views/user/notification_books/index.blade.php
@@ -1,0 +1,36 @@
+@extends('layouts.app')
+
+@section('title', '通知設定済書籍一覧')
+
+@section('content')
+<div class="container-fluid" id="app" style="max-width: 1200px">
+    <header class="bg-primary py-2 px-4 mb-3 text-center">
+        <h1 class="btn-collapse mb-0 text-white h5">通知設定済書籍一覧</h1>
+    </header>
+    <div class="row">
+        @forelse ($books as $book)
+        <div class="col-lg-3 col-md-4 col-6 mb-4">
+            <div class="card bg-white me-2 shadow" style="height: 375px;">
+                <a href="{{ route('user.books.show', $book->isbn) }}" class="text-decoration-none" style="display: flex; flex-direction: column; justify-content: center; align-items: center; width: 100%;">
+                    <img class="card-img-top mt-1" style="max-width: 125px; object-fit: contain;" src="{{ !empty($book->thumbnail) ? html_entity_decode($book->thumbnail) : asset('images/no-image.jpeg') }}" alt="thumbnail">
+                    <div class="card-body" style="flex-grow: 0;">
+                        <div class="card-text">{{ Str::limit($book->title, 80, '...') }}</div>
+                        <div class="card-text">
+                            <small class="text-muted">
+                                <span class="me-1"><i class="fas fa-user-circle"></i></span>
+                                {{ $book->authors->pluck('name')->implode(', ') }}
+                            </small>
+                        </div>
+                    </div>
+                </a>
+            </div>
+        </div>
+    @empty
+            <div class="alert alert-info text-center" role="alert">
+                「通知設定済書籍一覧」はまだありません。
+            </div>
+        @endforelse
+    </div>
+    {{ $books->links('pagination::bootstrap-5') }}
+</div>
+@endsection

--- a/routes/api.php
+++ b/routes/api.php
@@ -13,3 +13,4 @@ Route::controller(LibraryController::class)->name('libraries.')->group(static fu
 });
 Route::post('/books/toggleFavorite', [BookController::class, 'toggleFavorite'])->name('books.toggleFavorite');
 Route::post('/books/toggleRead', [BookController::class, 'toggleRead'])->name('books.toggleRead');
+Route::post('/books/toggleNotification', [BookController::class, 'toggleNotification'])->name('books.toggleNotification');

--- a/routes/web_user.php
+++ b/routes/web_user.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\User\ChangePasswordController;
 use App\Http\Controllers\User\ChangeEmailController;
 use App\Http\Middleware\PreventGuestAccess;
 use App\Http\Controllers\User\ReadBookController;
+use App\Http\Controllers\User\NotificationBookController;
 
 // 利用規約
 Route::view('/terms', 'user.other.terms')->name('terms');
@@ -63,6 +64,9 @@ Route::middleware(['auth:web', 'verified'])->group(static function () {
 
     // 読んだ本
     Route::get('/read_books', [ReadBookController::class, 'index'])->name('read_books.index');
+
+    // 通知する本
+    Route::get('/notification_books', [NotificationBookController::class, 'index'])->name('notification_books.index');
 
     // レビューの登録・編集・削除
     Route::controller(ReviewController::class)->name('reviews.')->group(static function () {

--- a/tests/Feature/Controllers/API/BookControllerTest.php
+++ b/tests/Feature/Controllers/API/BookControllerTest.php
@@ -105,4 +105,51 @@ class BookControllerTest extends TestCase
             $this->assertDatabaseMissing('book_authors', ['name' => $author, 'book_id' => $book->id]);
         }
     }
+
+    public function testToggleNotification(): void
+    {
+        $user = User::factory()->create();
+        $isbn = '1234567890';
+        $title = 'Test Book';
+        $thumbnail = 'http://example.com/thumbnail.jpg';
+        $authors = ['Author 1', 'Author 2'];
+
+        // 初回の通知追加
+        $response = $this->postJson(route('api.books.toggleNotification'), [
+            'user_id' => $user->id,
+            'isbn' => $isbn,
+            'title' => $title,
+            'thumbnail' => $thumbnail,
+            'authors' => $authors,
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJson(['status' => 'success']);
+
+        $book = Book::where('isbn', $isbn)->first();
+
+        $this->assertDatabaseHas('books', ['isbn' => $isbn, 'title' => $title, 'thumbnail' => $thumbnail]);
+        foreach ($authors as $author) {
+            $this->assertDatabaseHas('book_authors', ['name' => $author, 'book_id' => $book->id]);
+        }
+        $this->assertDatabaseHas('notification_books', ['user_id' => $user->id, 'book_id' => $book->id]);
+
+        // 2回目の通知削除
+        $response = $this->postJson(route('api.books.toggleNotification'), [
+            'user_id' => $user->id,
+            'isbn' => $isbn,
+            'title' => $title,
+            'thumbnail' => $thumbnail,
+            'authors' => $authors,
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJson(['status' => 'success']);
+
+        $this->assertDatabaseMissing('notification_books', ['user_id' => $user->id, 'book_id' => $book->id]);
+        $this->assertDatabaseMissing('books', ['isbn' => $isbn, 'title' => $title, 'thumbnail' => $thumbnail]);
+        foreach ($authors as $author) {
+            $this->assertDatabaseMissing('book_authors', ['name' => $author, 'book_id' => $book->id]);
+        }
+    }
 }

--- a/tests/Feature/Controllers/User/NotificationBookControllerTest.php
+++ b/tests/Feature/Controllers/User/NotificationBookControllerTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Feature\Controllers\User;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+use App\Models\User;
+use App\Models\Book;
+
+class NotificationBookControllerTest extends TestCase
+{
+    use RefreshDatabase, WithFaker;
+
+    public function testIndex(): void
+    {
+        $user = User::factory()->create();
+        $books = Book::factory(3)->create();
+        $user->notificationBooks()->attach($books->pluck('id'));
+
+        $response = $this->actingAs($user)
+            ->get(route('user.notification_books.index'));
+
+        $response->assertStatus(200);
+        $response->assertViewIs('user.notification_books.index');
+        $response->assertViewHas('books', function ($viewBooks) use ($books) {
+            return $viewBooks->pluck('id')->diff($books->pluck('id'))->isEmpty();
+        });
+    }
+}


### PR DESCRIPTION
## やったこと
- 通知処理の実装にあたって、貸出不可の書籍を通知設定に追加できる機能を実装
- 書籍詳細画面で貸し出し不可の書籍の場合、通知設定ボタンを表示させる
- 通知ボタンを押すと通知設定済書籍一覧に追加される
- 通知設定済書籍一覧画面で追加した書籍の一覧を確認できる